### PR TITLE
Replace hyphen char by double dashes in command lines

### DIFF
--- a/content/build/maven/setup.adoc
+++ b/content/build/maven/setup.adoc
@@ -108,7 +108,7 @@ TBD
 
 [source,shell]
 ----
-$ gpg –version
+$ gpg --version
 gpg (GnuPG) 1.4.10
 Copyright (C) 2008 Free Software Foundation, Inc.
 License GPLv3+: GNU GPL version 3 or later http://gnu.org/licenses/gpl.html[http://gnu.org/licenses/gpl.html]
@@ -150,7 +150,7 @@ Launch the key generation
 
 [source,shell]
 ----
-$ gpg –gen-key
+$ gpg --gen-key
 ----
 
 *ALWAYS SELECT DEFAULT CHOICES AND DON'T USE AN EMPTY PASSPHRASE*
@@ -167,7 +167,7 @@ You can list the key you just generated with :
 
 [source,shell]
 ----
-$ gpg –list-key
+$ gpg --list-key
 pub 4096R/2CF0CC82 2009-11-17
 uid Arnaud Héritier (eXo Platform CODE SIGNING KEY) arnaud.heritier@exoplatform.com
 sub 4096R/37540EAE 2009-11-17
@@ -177,7 +177,7 @@ You send your key to a PGP server (you use the ID from the "pub" line)
 
 [source,shell]
 ----
-$ gpg –keyserver hkp://pgp.mit.edu[hkp://pgp.mit.edu] –send-keys 2CF0CC82
+$ gpg --keyserver hkp://pgp.mit.edu[hkp://pgp.mit.edu] --send-keys 2CF0CC82
 ----
 
 Your GPG key is now ready to be used

--- a/content/sources/settings.adoc
+++ b/content/sources/settings.adoc
@@ -27,8 +27,8 @@ By default you have at least to setup your default identity that will be used fo
 
 [source,shell]
 ----
-git config –global user.name "John Doe"
-git config –global user.email "jdoe@exoplatform.com"
+git config --global user.name "John Doe"
+git config --global user.email "jdoe@exoplatform.com"
 ----
 
 We recommend also :
@@ -44,30 +44,30 @@ git config color.ui true
 
 [source,shell]
 ----
-git config –global push.default current
+git config --global push.default current
 ----
 
 * to setup line endings preferences for Unix/Mac users
 
 [source,shell]
 ----
-git config –global core.autocrlf input
-git config –global core.safecrlf true
+git config --global core.autocrlf input
+git config --global core.safecrlf true
 ----
 
 * to setup line endings preferences for Windows users
 
 [source,shell]
 ----
-git config –global core.autocrlf true
-git config –global core.safecrlf true
+git config --global core.autocrlf true
+git config --global core.safecrlf true
 ----
 
 * to reduce the number of files to consider when performing rename detection during a merge. The merge is working pretty well on small repositories (with move and rename of files). But it's not working on large repositories as the detection of file renaming is O(n²), so we need to update some threshold (more explanations are available in this post : http://blogs.atlassian.com/2011/10/confluence_git_rename_merge_oh_my/[http://blogs.atlassian.com/2011/10/confluence_git_rename_merge_oh_my/]) :
 
 [source,shell]
 ----
- git config –global merge.renameLimit 10000
+ git config --global merge.renameLimit 10000
 ----
 
 * to configure git to add some command aliases to easily call them with `git &lt;ALIAS_NAME&gt;`.

--- a/content/sources/workflow.adoc
+++ b/content/sources/workflow.adoc
@@ -218,7 +218,7 @@ git pull
 git rebase origin/develop
 git checkout develop
 git pull
-git merge fix/issue –squash
+git merge fix/issue --squash
 git commit -a
 git push
 ----
@@ -232,7 +232,7 @@ git push
 *How:*
 [source,shell]
 ----
-git push origin –delete fix/issue
+git push origin --delete fix/issue
 git branch -d fix/issue
 ----
 


### PR DESCRIPTION
This PR restore the double dashes in the command lines where they were replaced by hyphen char