### PR TITLE
Add Google Analytics code

### DIFF
--- a/docinfo.html
+++ b/docinfo.html
@@ -1,0 +1,9 @@
+<script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-1292368-31', 'auto');
+    ga('send', 'pageview');
+</script>


### PR DESCRIPTION
  * Since July 2016 and the V2 with AsciiDoc, the GA code was not
  present in the HTML. With the docinfo Asciidoctor feature, the JS
  can be injected into the HTML output.