### PR TITLE
Update PR commit message template

### DIFF
--- a/content/sources/contributions.adoc
+++ b/content/sources/contributions.adoc
@@ -96,7 +96,7 @@ git commit -m “My commit message”
 when committing a change, in order to write a more detailed commit message and use the commit template
 
 * the commit message must start with a line containing a short subject (max 100 characters) which starts by the Jira issue number and then describes briefly what the commit does. 
-For example : PLF-7916 : Make Setting Service cache ayncInvalidation
+For example : TASK-40308 Allow to update kudos message in activity stream
 * the commit subject must not be a copy/paste of the Jira issue summary. 
 As said previously, it must describe what the commit does, as if the sentence would start with “If applied, this commit will ...”.
 * after the subject, one blank line must be added before starting the body
@@ -107,20 +107,9 @@ Here is an example of commit message following these rules:
 
 [source,shell]
 ----
-PLF-8070 : remove useless configuration about settings and notifications services
+TASK-37899 Enhance extension registry to trigger event when extensions updated
 
-At first access after startup, if the eXo instance has never been registered, the servlet /registration/software-register is called, then the servlet /registration/software-register-action when clicking on a button.
-The servlet /registration/software-register-action needs to read and update a setting, so it needs the service org.exoplatform.commons.api.settings.SettingService.
-The JPA implementation of this service needs the EntityManagerService to fetch data, which is available only in the PortalContainer.
-And the available container when accessing the servlet is actually the RootContainer.
-In PLF 5.0.0-M10 (in which the bug does not occur), the SettingService implementation used is the cached impl (org.exoplatform.settings.cache.CacheSettingServiceImpl), and when we call the get method to read a settings, it calls the method org.exoplatform.commons.api.settings.data.SettingContext#getCurrentRepositoryName which creates the PortalContainer instance by calling PortalContainer.getInstance().
-Therefore, luckily, when the EntityManagerService is retrieved from the container, the current container is the PortalContainer and it is available and everything works fine.
-
-From SOC-5917, a configuration has been added in social project which changes the implementation of the SettingService from the cached one to org.exoplatform.settings.jpa.JPAUserSettingServiceImpl :  25c143c#diff-a874bcc27e08363c8bcf7f9ce8eab5a7R346
-And this implementation never calls PortalContainer.getInstance(), which means the container available in the servlet is the RootContainer which does not contain EntityManagerService, which makes the setting read fails.
-
-This fix removes the configuration added in SOC-5917 about settings, so the cached impl will be used again.
-Also, a fix in the servlet is done (in the platform project) to ensure that the PortalContainer is created when fetching the setting, no matter what the implementation of SettingService.
+When updating extensionRegistry asynchronously from different modules, the other modules should be triggered for this update to allow retrieving newly registered extensions. This way, the extension points in all portlets will can be aware, when listening to adequate event, of any change in extensionRegistry.
 ----
 
 Of course, all commit messages do not need to be that long, but it must contain all relevant information to understand what and why the changes have been done.
@@ -131,7 +120,7 @@ In order to help developers, a template is available.
 
 [source,shell]
 ----
-# <jira-issue-id>: (If applied, this commit will...) <subject>
+# TASK-<task-id>: (If applied, this commit will...) <subject>
 # |<----  Using a Maximum Of 100 Characters  ---->|
 
 # Why is this change needed?
@@ -178,7 +167,7 @@ git config commit.template <.git-commit-template.txt file path>
 As well as good commits messages are important for code base maintainers, good PRs descriptions are important for reviewers. 
 It helps to understand what the developer has done and why.
 The PR title must start with the Jira issue, then describe briefly what the PR does. 
-For example : _PLF-7916 : Make Setting Service cache ayncInvalidation_
+For example : _TASK-40308 Allow to update kudos message in activity stream_
 
 The PR description must at least provide the information given in the commit message body : why is this change needed and how does this change address the issue (Tip: using the first line of the commit message as the PR title and the commit message body as the PR description is a good start for the PR description).
 


### PR DESCRIPTION
Prior to this change, the JIRA issues was used in commit message templates.
The issue tracking is now moved to use eXo Task application, thus the commit messages template has to be updated.